### PR TITLE
Feature/throttle

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -2,22 +2,20 @@ function Cache(expiration /* seconds */) {
   this.entries = {};
   this.expiration = 5;
 
-  if (expiration != null) {
+  if (expiration)
     this.expiration = expiration;
-  }
 }
 
-Cache.prototype.get = function(key) {
+Cache.prototype.get = function (key) {
   const entry = this.entries[key];
 
-  if (entry != null) {
+  if (entry)
     return entry.value;
-  }
 
   return undefined;
-}
+};
 
-Cache.prototype.set = function(key, value) {
+Cache.prototype.set = function (key, value) {
   const timestamp = Date.now();
 
   this.entries[key] = {
@@ -25,20 +23,19 @@ Cache.prototype.set = function(key, value) {
     value,
     timestamp
   };
-}
+};
 
-Cache.prototype.has = function(key) {
-  return this.entries[key] != null;
-}
+Cache.prototype.has = function (key) {
+  return this.entries[key] !== undefined;
+};
 
-Cache.prototype.remove = function(key) {
+Cache.prototype.remove = function (key) {
   delete this.entries[key];
-}
+};
 
-Cache.prototype.expired = function(key) {
-  if (!this.has(key)) {
+Cache.prototype.expired = function (key) {
+  if (!this.has(key))
     return true;
-  }
 
   const entry = this.entries[key];
   const delta = Math.abs(entry.timestamp - Date.now()) / 1000;
@@ -50,6 +47,6 @@ Cache.prototype.expired = function(key) {
   }
 
   return false;
-}
+};
 
 module.exports = Cache;

--- a/cache.js
+++ b/cache.js
@@ -1,0 +1,55 @@
+function Cache(expiration /* seconds */) {
+  this.entries = {};
+  this.expiration = 5;
+
+  if (expiration != null) {
+    this.expiration = expiration;
+  }
+}
+
+Cache.prototype.get = function(key) {
+  const entry = this.entries[key];
+
+  if (entry != null) {
+    return entry.value;
+  }
+
+  return undefined;
+}
+
+Cache.prototype.set = function(key, value) {
+  const timestamp = Date.now();
+
+  this.entries[key] = {
+    key,
+    value,
+    timestamp
+  };
+}
+
+Cache.prototype.has = function(key) {
+  return this.entries[key] != null;
+}
+
+Cache.prototype.remove = function(key) {
+  delete this.entries[key];
+}
+
+Cache.prototype.expired = function(key) {
+  if (!this.has(key)) {
+    return true;
+  }
+
+  const entry = this.get(key);
+  const delta = Math.abs(entry.timestamp - Date.now()) / 1000;
+  const seconds = delta % 60;
+
+  if (seconds > this.expiration) {
+    this.remove(key);
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = Cache;

--- a/cache.js
+++ b/cache.js
@@ -40,7 +40,7 @@ Cache.prototype.expired = function(key) {
     return true;
   }
 
-  const entry = this.get(key);
+  const entry = this.entries[key];
   const delta = Math.abs(entry.timestamp - Date.now()) / 1000;
   const seconds = delta % 60;
 

--- a/index.js
+++ b/index.js
@@ -336,7 +336,7 @@ Daikin.prototype = {
         this.sendGetRequest(this.set_control_info + '?' + query, response => {
           callback();
         }, true /* bypassCache */);
-    });
+    }, true /* bypassCache */);
   },
 
   getSwingMode(callback) {
@@ -364,7 +364,7 @@ Daikin.prototype = {
       this.sendGetRequest(this.set_control_info + '?' + query, response => {
         callback();
       }, true /* bypassCache */);
-    });
+    }, true /* bypassCache */);
   },
 
   getHeaterCoolerState(callback) {
@@ -447,7 +447,7 @@ Daikin.prototype = {
                   this.sendGetRequest(this.set_control_info + '?' + query, response => {
                       callback();
                   }, true /* bypassCache */);
-              });
+              }, true /* bypassCache */);
         },
 
   getCurrentTemperature(callback) {
@@ -476,7 +476,7 @@ Daikin.prototype = {
           this.sendGetRequest(this.set_control_info + '?' + query, response => {
                     callback();
                 }, true /* bypassCache */);
-            });
+            }, true /* bypassCache */);
         },
 
   getHeatingTemperature(callback) {
@@ -497,7 +497,7 @@ Daikin.prototype = {
           this.sendGetRequest(this.set_control_info + '?' + query, response => {
                       callback();
                   }, true /* bypassCache */);
-              });
+              }, true /* bypassCache */);
           },
 
   identify: function (callback) {
@@ -610,7 +610,7 @@ getFanSpeed: function (callback) {
         this.sendGetRequest(this.set_control_info + '?' + query, response => {
           callback();
         }, true /* bypassCache */);
-      });
+      }, true /* bypassCache */);
   },
 
   setFanSpeed: function (value, callback) {
@@ -624,7 +624,7 @@ getFanSpeed: function (callback) {
       this.sendGetRequest(this.set_control_info + '?' + query, response => {
         callback();
       }, true /* bypassCache */);
-    });
+    }, true /* bypassCache */);
   },
 
   getTemperatureDisplayUnits: function (callback) {

--- a/index.js
+++ b/index.js
@@ -246,6 +246,7 @@ Daikin.prototype = {
 
           this.log.debug('queued request finished: path: %s', path);
 
+          // actual response callback
           callback(res);
           done();
         }, skipCache);

--- a/index.js
+++ b/index.js
@@ -196,10 +196,9 @@ Daikin.prototype = {
   },
 
   sendGetRequest(path, callback, bypassCache) {
-    if (this._serveFromCache(path, callback, bypassCache)) {
+    if (this._serveFromCache(path, callback, bypassCache))
       return;
-    }
- 
+
     this._queueGetRequest(path, callback, bypassCache);
   },
 
@@ -239,7 +238,7 @@ Daikin.prototype = {
 
         this._doSendGetRequest(path, (err, res) => {
           if (err) {
-            this.log.error('ERROR: Queued request to %s returned error %s', path, err)
+            this.log.error('ERROR: Queued request to %s returned error %s', path, err);
             done();
             return;
           }
@@ -253,9 +252,8 @@ Daikin.prototype = {
   },
 
   _doSendGetRequest(path, callback, bypassCache) {
-    if (this._serveFromCache(path, callback, bypassCache)) {
+    if (this._serveFromCache(path, callback, bypassCache))
       return;
-    }
 
     this.log.debug('requesting from API: path: %s', path);
     superagent
@@ -275,7 +273,7 @@ Daikin.prototype = {
         }
 
         if (!bypassCache) {
-          this.log.debug('set cache: path: %s', path)
+          this.log.debug('set cache: path: %s', path);
           this.cache.set(path, res.text);
         }
 

--- a/index.js
+++ b/index.js
@@ -196,15 +196,15 @@ Daikin.prototype = {
   },
 
   sendGetRequest(path, callback, bypassCache) {
-    if (this.serveFromCache(path, callback, bypassCache)) {
+    if (this._serveFromCache(path, callback, bypassCache)) {
       return;
     }
  
     this.log.debug('queue sendGetRequest: path: %s', path);
-    this.queueGetRequest(path, callback, bypassCache);
+    this._queueGetRequest(path, callback, bypassCache);
   },
 
-  serveFromCache(path, callback, bypassCache) {
+  _serveFromCache(path, callback, bypassCache) {
     if (bypassCache) {
       return false;
     }
@@ -227,11 +227,11 @@ Daikin.prototype = {
     return true;
   },
 
-  queueGetRequest(path, callback, bypassCache) {
+  _queueGetRequest(path, callback, bypassCache) {
     this.queue.add(done => {
       this.log.debug('execute sendGetRequest: path: %s', path);
 
-        this.doSendGetRequest(path, (err, res) => {
+        this._doSendGetRequest(path, (err, res) => {
           if (err) {
             this.log.error('ERROR: Cache %s returned error %s', path, err)
             done();
@@ -244,8 +244,8 @@ Daikin.prototype = {
     });
   },
 
-  doSendGetRequest(path, callback, bypassCache) {
-    if (this.serveFromCache(path, callback, bypassCache)) {
+  _doSendGetRequest(path, callback, bypassCache) {
+    if (this._serveFromCache(path, callback, bypassCache)) {
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -272,10 +272,8 @@ Daikin.prototype = {
           return this.log.error('ERROR: API request to %s returned error %s', path, err);
         }
 
-        if (!bypassCache) {
-          this.log.debug('set cache: path: %s', path);
-          this.cache.set(path, res.text);
-        }
+        this.log.debug('set cache: path: %s', path);
+        this.cache.set(path, res.text);
 
         this.log.debug('responding from API: %s', JSON.stringify(res.text));
         callback(err, res.text);

--- a/index.js
+++ b/index.js
@@ -8,6 +8,14 @@ const packageFile = require('./package.json');
 
 function Daikin(log, config) {
   this.log = log;
+
+  this.throttle = new Throttle({
+    active: true, // set false to pause queue
+    rate: 1, // how many requests can be sent every `ratePer`
+    ratePer: 1000, // number of ms in which `rate` requests may be sent
+    concurrent: 1 // how many requests can be sent concurrently
+  });
+
   if (config.name === undefined) {
     this.log.error('ERROR: your configuration is missing the parameter "name"');
     this.name = 'Unnamed Daikin';
@@ -198,7 +206,7 @@ sendGetRequest(path, callback) {
       response: this.response, // 2000, // Wait 2 seconds for the server to start sending,
       deadline: this.deadline // 60000 // but allow 1 minute for the request to finish loading.
     })
-    .use(throttle.plugin())
+    .use(this.throttle.plugin())
     .set('User-Agent', 'superagent')
     .set('Host', this.apiIP)
     .end((err, res) => {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function Daikin(log, config) {
   this.throttle = new Throttle({
     active: true, // set false to pause queue
     rate: 1, // how many requests can be sent every `ratePer`
-    ratePer: 1000, // number of ms in which `rate` requests may be sent
+    ratePer: 500, // number of ms in which `rate` requests may be sent
     concurrent: 1 // how many requests can be sent concurrently
   });
 

--- a/index.js
+++ b/index.js
@@ -191,13 +191,6 @@ Daikin.prototype = {
   },
 
 sendGetRequest(path, callback) {
-  const throttle = new Throttle({
-    active: true, // set false to pause queue
-    rate: 1, // how many requests can be sent every `ratePer`
-    ratePer: 500, // number of ms in which `rate` requests may be sent
-    concurrent: 1 // how many requests can be sent concurrently
-  });
-
   this.log.debug('sendGetRequest: path: %s', path);
   superagent
     .get(path)

--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ Daikin.prototype = {
     }
 
     this.log.debug('cache HIT: path: %s', path);
-    this.log.debug('responding from cache: %s', JSON.stringify(cachedResponse));
+    this.log.debug('responding from cache: %s', cachedResponse);
 
     callback(null, cachedResponse);
     return true;
@@ -279,7 +279,7 @@ Daikin.prototype = {
         this.log.debug('set cache: path: %s', path);
         this.cache.set(path, res.text);
 
-        this.log.debug('responding from API: %s', JSON.stringify(res.text));
+        this.log.debug('responding from API: %s', res.text);
         callback(err, res.text);
         // Calling the end function will send the request
       });

--- a/index.js
+++ b/index.js
@@ -220,10 +220,14 @@ Daikin.prototype = {
       return false;
     }
 
-    this.log.debug('cache HIT: path: %s', path);
-
     const cachedResponse = this.cache.get(path);
 
+    if (cachedResponse === undefined) {
+      this.log.debug('cache EMPTY: path: %s', path);
+      return false;
+    }
+
+    this.log.debug('cache HIT: path: %s', path);
     this.log.debug('responding from cache: %s', JSON.stringify(cachedResponse));
 
     callback(null, cachedResponse);

--- a/index.js
+++ b/index.js
@@ -195,17 +195,17 @@ Daikin.prototype = {
     return vals;
   },
 
-  sendGetRequest(path, callback, bypassCache) {
-    if (this._serveFromCache(path, callback, bypassCache))
+  sendGetRequest(path, callback, skipCache) {
+    if (this._serveFromCache(path, callback, skipCache))
       return;
 
-    this._queueGetRequest(path, callback, bypassCache);
+    this._queueGetRequest(path, callback, skipCache);
   },
 
-  _serveFromCache(path, callback, bypassCache) {
+  _serveFromCache(path, callback, skipCache) {
     this.log.debug('requesting from cache: path: %s', path);
 
-    if (bypassCache) {
+    if (skipCache) {
       this.log.debug('cache SKIP: path: %s', path);
       return false;
     }
@@ -234,7 +234,7 @@ Daikin.prototype = {
     return true;
   },
 
-  _queueGetRequest(path, callback, bypassCache) {
+  _queueGetRequest(path, callback, skipCache) {
     this.log.debug('queuing request: path: %s', path);
 
     this.queue.add(done => {
@@ -251,12 +251,12 @@ Daikin.prototype = {
 
           callback(res);
           done();
-        }, bypassCache);
+        }, skipCache);
     });
   },
 
-  _doSendGetRequest(path, callback, bypassCache) {
-    if (this._serveFromCache(path, callback, bypassCache))
+  _doSendGetRequest(path, callback, skipCache) {
+    if (this._serveFromCache(path, callback, skipCache))
       return;
 
     this.log.debug('requesting from API: path: %s', path);
@@ -342,8 +342,8 @@ Daikin.prototype = {
 
         this.sendGetRequest(this.set_control_info + '?' + query, response => {
           callback();
-        }, true /* bypassCache */);
-    }, true /* bypassCache */);
+        }, true /* skipCache */);
+    }, true /* skipCache */);
   },
 
   getSwingMode(callback) {
@@ -370,8 +370,8 @@ Daikin.prototype = {
       this.log.debug('setSwingMode: swing mode: %s, query is: %s', swing, query);
       this.sendGetRequest(this.set_control_info + '?' + query, response => {
         callback();
-      }, true /* bypassCache */);
-    }, true /* bypassCache */);
+      }, true /* skipCache */);
+    }, true /* skipCache */);
   },
 
   getHeaterCoolerState(callback) {
@@ -453,8 +453,8 @@ Daikin.prototype = {
                   this.log.info('setTargetHeaterCoolerState: query: %s', query);
                   this.sendGetRequest(this.set_control_info + '?' + query, response => {
                       callback();
-                  }, true /* bypassCache */);
-              }, true /* bypassCache */);
+                  }, true /* skipCache */);
+              }, true /* skipCache */);
         },
 
   getCurrentTemperature(callback) {
@@ -482,8 +482,8 @@ Daikin.prototype = {
             .replace(/dt3=[0-9.]+/, `dt3=${temp}`);
           this.sendGetRequest(this.set_control_info + '?' + query, response => {
                     callback();
-                }, true /* bypassCache */);
-            }, true /* bypassCache */);
+                }, true /* skipCache */);
+            }, true /* skipCache */);
         },
 
   getHeatingTemperature(callback) {
@@ -503,8 +503,8 @@ Daikin.prototype = {
               .replace(/dt3=[0-9.]+/, `dt3=${temp}`);
           this.sendGetRequest(this.set_control_info + '?' + query, response => {
                       callback();
-                  }, true /* bypassCache */);
-              }, true /* bypassCache */);
+                  }, true /* skipCache */);
+              }, true /* skipCache */);
           },
 
   identify: function (callback) {
@@ -616,8 +616,8 @@ getFanSpeed: function (callback) {
         this.log.debug('setFanSatus: query stage 2 is: %s', query);
         this.sendGetRequest(this.set_control_info + '?' + query, response => {
           callback();
-        }, true /* bypassCache */);
-      }, true /* bypassCache */);
+        }, true /* skipCache */);
+      }, true /* skipCache */);
   },
 
   setFanSpeed: function (value, callback) {
@@ -630,8 +630,8 @@ getFanSpeed: function (callback) {
       this.log.debug('setFanSpeed: Query is: %s', query);
       this.sendGetRequest(this.set_control_info + '?' + query, response => {
         callback();
-      }, true /* bypassCache */);
-    }, true /* bypassCache */);
+      }, true /* skipCache */);
+    }, true /* skipCache */);
   },
 
   getTemperatureDisplayUnits: function (callback) {

--- a/index.js
+++ b/index.js
@@ -196,9 +196,6 @@ Daikin.prototype = {
   },
 
   sendGetRequest(path, callback, skipCache) {
-    if (this._serveFromCache(path, callback, skipCache))
-      return;
-
     this._queueGetRequest(path, callback, skipCache);
   },
 

--- a/index.js
+++ b/index.js
@@ -199,38 +199,6 @@ Daikin.prototype = {
     this._queueGetRequest(path, callback, skipCache);
   },
 
-  _serveFromCache(path, callback, skipCache) {
-    this.log.debug('requesting from cache: path: %s', path);
-
-    if (skipCache) {
-      this.log.debug('cache SKIP: path: %s', path);
-      return false;
-    }
-
-    if (!this.cache.has(path)) {
-      this.log.debug('cache MISS: path: %s', path);
-      return false;
-    }
-
-    if (this.cache.expired(path)) {
-      this.log.debug('cache EXPIRED: path: %s', path);
-      return false;
-    }
-
-    const cachedResponse = this.cache.get(path);
-
-    if (cachedResponse === undefined) {
-      this.log.debug('cache EMPTY: path: %s', path);
-      return false;
-    }
-
-    this.log.debug('cache HIT: path: %s', path);
-    this.log.debug('responding from cache: %s', cachedResponse);
-
-    callback(null, cachedResponse);
-    return true;
-  },
-
   _queueGetRequest(path, callback, skipCache) {
     this.log.debug('queuing request: path: %s', path);
 
@@ -281,6 +249,38 @@ Daikin.prototype = {
         callback(err, res.text);
         // Calling the end function will send the request
       });
+  },
+
+  _serveFromCache(path, callback, skipCache) {
+    this.log.debug('requesting from cache: path: %s', path);
+
+    if (skipCache) {
+      this.log.debug('cache SKIP: path: %s', path);
+      return false;
+    }
+
+    if (!this.cache.has(path)) {
+      this.log.debug('cache MISS: path: %s', path);
+      return false;
+    }
+
+    if (this.cache.expired(path)) {
+      this.log.debug('cache EXPIRED: path: %s', path);
+      return false;
+    }
+
+    const cachedResponse = this.cache.get(path);
+
+    if (cachedResponse === undefined) {
+      this.log.debug('cache EMPTY: path: %s', path);
+      return false;
+    }
+
+    this.log.debug('cache HIT: path: %s', path);
+    this.log.debug('responding from cache: %s', cachedResponse);
+
+    callback(null, cachedResponse);
+    return true;
   },
 
   getActive(callback) {

--- a/index.js
+++ b/index.js
@@ -232,10 +232,10 @@ Daikin.prototype = {
   },
 
   _queueGetRequest(path, callback, bypassCache) {
-    this.log.debug('queue request: path: %s', path);
+    this.log.debug('queuing request: path: %s', path);
 
     this.queue.add(done => {
-      this.log.debug('execute queued request: path: %s', path);
+      this.log.debug('executing queued request: path: %s', path);
 
         this._doSendGetRequest(path, (err, res) => {
           if (err) {

--- a/index.js
+++ b/index.js
@@ -196,6 +196,7 @@ Daikin.prototype = {
   },
 
   sendGetRequest(path, callback, skipCache) {
+    this.log.debug('attempting request: path: %s', path);
     this._queueGetRequest(path, callback, skipCache);
   },
 

--- a/index.js
+++ b/index.js
@@ -195,6 +195,15 @@ Daikin.prototype = {
     return vals;
   },
 
+  sendGetRequest(path, callback, bypassCache) {
+    if (this.serveFromCache(path, callback, bypassCache)) {
+      return;
+    }
+ 
+    this.log.debug('queue sendGetRequest: path: %s', path);
+    this.queueGetRequest(path, callback, bypassCache);
+  },
+
   serveFromCache(path, callback, bypassCache) {
     if (bypassCache) {
       return false;
@@ -233,15 +242,6 @@ Daikin.prototype = {
           done();
         }, bypassCache);
     });
-  },
-
-  sendGetRequest(path, callback, bypassCache) {
-    if (this.serveFromCache(path, callback, bypassCache)) {
-      return;
-    }
- 
-    this.log.debug('queue sendGetRequest: path: %s', path);
-    this.queueGetRequest(path, callback, bypassCache);
   },
 
   doSendGetRequest(path, callback, bypassCache) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-daikin-local",
-  "version": "2020.21.1",
+  "version": "2020.21.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2102,6 +2102,11 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "function-queue": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/function-queue/-/function-queue-0.0.12.tgz",
+      "integrity": "sha1-us+7w90sMqWnY+/aGZ+wBgDQ/Zo="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2103,11 +2103,6 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "function-queue": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/function-queue/-/function-queue-0.0.12.tgz",
-      "integrity": "sha1-us+7w90sMqWnY+/aGZ+wBgDQ/Zo="
-    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "url": "git+https://github.com/cbrandlehner/homebridge-daikin-local.git"
   },
   "dependencies": {
-    "function-queue": "0.0.12",
     "superagent": ">=5.2.2",
     "superagent-throttle": ">=1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "git+https://github.com/cbrandlehner/homebridge-daikin-local.git"
   },
   "dependencies": {
+    "function-queue": "0.0.12",
     "superagent": ">=5.2.2",
     "superagent-throttle": ">=1.0.1"
   },

--- a/queue.js
+++ b/queue.js
@@ -1,0 +1,29 @@
+function Queue() {
+  this.queue = [];
+  this.running = false;
+}
+
+Queue.prototype.add = function(callback) { 
+    this.queue.push(() => {
+      const next = this.next.bind(this);
+      callback(next);
+    });
+
+    if (!this.running) {
+      this.next();
+    }
+
+    return this;
+}
+
+Queue.prototype.next = function(){
+    this.running = false;
+
+    const shift = this.queue.shift(); 
+    if(shift) { 
+      this.running = true;
+      shift(); 
+    }
+}
+
+module.exports = Queue;

--- a/queue.js
+++ b/queue.js
@@ -18,10 +18,10 @@ Queue.prototype.add = function (callback) {
 Queue.prototype.next = function () {
   this.running = false;
 
-  const shift = this.queue.shift();
-  if (shift) {
+  const next = this.queue.shift();
+  if (next) {
     this.running = true;
-    shift();
+    next();
   }
 };
 

--- a/queue.js
+++ b/queue.js
@@ -3,27 +3,26 @@ function Queue() {
   this.running = false;
 }
 
-Queue.prototype.add = function(callback) { 
-    this.queue.push(() => {
-      const next = this.next.bind(this);
-      callback(next);
-    });
+Queue.prototype.add = function (callback) {
+  this.queue.push(() => {
+    const next = this.next.bind(this);
+    callback(next);
+  });
 
-    if (!this.running) {
-      this.next();
-    }
+  if (!this.running)
+    this.next();
 
-    return this;
-}
+  return this;
+};
 
-Queue.prototype.next = function(){
-    this.running = false;
+Queue.prototype.next = function () {
+  this.running = false;
 
-    const shift = this.queue.shift(); 
-    if(shift) { 
-      this.running = true;
-      shift(); 
-    }
-}
+  const shift = this.queue.shift();
+  if (shift) {
+    this.running = true;
+    shift();
+  }
+};
 
 module.exports = Queue;


### PR DESCRIPTION
I have been having issues with **slow updates** and **connection timeouts** (see https://github.com/cbrandlehner/homebridge-daikin-local/issues/67) and found out, that duplicate requests are bing fired, due to how data is collected from devices.

So what I have tried was to

- [x] instantiate `Throttle` only once per device and put all requests through it,
- [x] queue all requests, which makes it possible to
- [x] cache responses (for 5 seconds) and reuse it in the next queued request.

This is a very simple initial implementation and could be improved a lot. Ideas include

- make the cache expiration configurable, 
- improve how to bypass the cache (currently boolean parameter), and
- debounce requests that change a value, instead of bypassing the cache.

However, it improves performance quite a lot for me, and I didn't see any connection timeouts anymore.

Thanks for rewriting this Homebridge plugin 🎉 