### PR TITLE
Fix unexpected switch off and timeouts

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,35 +201,16 @@ Daikin.prototype = {
 
   sendGetRequest(path, callback, skipCache, skipQueue) {
     this.log.debug('attempting request: path: %s', path);
-    this.log.debug('skipping cache is set to %s', skipCache);
 
-    if (skipQueue) {
-      this.log.debug('skipping queue: path: %s', path);
-      this._immediateGetRequest(path, callback, skipCache);
-      return;
-    }
-
-    this._queuedGetRequest(path, callback, skipCache);
+    this._queueGetRequest(path, callback, skipCache, skipQueue);
   },
 
-  _immediateGetRequest(path, callback, skipCache) {
-    this._doSendGetRequest(path, (err, res) => {
-      if (err) {
-        this.log.error('ERROR: request to %s returned error %s', path, err);
-        return;
-      }
+  _queueGetRequest(path, callback, skipCache, skipQueue) {
+    const method = skipQueue ? 'prepend' : 'append';
 
-      this.log.debug('request finished: path: %s', path);
+    this.log.debug(`queuing (${method}) request: path: %s`, path);
 
-      // actual response callback
-      callback(res);
-    }, skipCache);
-  },
-
-  _queuedGetRequest(path, callback, skipCache) {
-    this.log.debug('queuing request: path: %s', path);
-
-    this.queue.add(done => {
+    this.queue[method](done => {
       this.log.debug('executing queued request: path: %s', path);
 
         this._doSendGetRequest(path, (err, res) => {

--- a/index.js
+++ b/index.js
@@ -199,14 +199,14 @@ Daikin.prototype = {
     return vals;
   },
 
-  sendGetRequest(path, callback, skipCache, skipQueue) {
+  sendGetRequest(path, callback, options) {
     this.log.debug('attempting request: path: %s', path);
 
-    this._queueGetRequest(path, callback, skipCache, skipQueue);
+    this._queueGetRequest(path, callback, options);
   },
 
-  _queueGetRequest(path, callback, skipCache, skipQueue) {
-    const method = skipQueue ? 'prepend' : 'append';
+  _queueGetRequest(path, callback, options) {
+    const method = options.skipQueue ? 'prepend' : 'append';
 
     this.log.debug(`queuing (${method}) request: path: %s`, path);
 
@@ -225,12 +225,12 @@ Daikin.prototype = {
           // actual response callback
           callback(res);
           done();
-        }, skipCache);
+        }, options);
     });
   },
 
-  _doSendGetRequest(path, callback, skipCache) {
-    if (this._serveFromCache(path, callback, skipCache))
+  _doSendGetRequest(path, callback, options) {
+    if (this._serveFromCache(path, callback, options))
       return;
 
     this.log.debug('requesting from API: path: %s', path);
@@ -259,10 +259,10 @@ Daikin.prototype = {
       });
   },
 
-  _serveFromCache(path, callback, skipCache) {
+  _serveFromCache(path, callback, options) {
     this.log.debug('requesting from cache: path: %s', path);
 
-    if (skipCache) {
+    if (options.skipCache) {
       this.log.debug('cache SKIP: path: %s', path);
       return false;
     }
@@ -349,8 +349,8 @@ Daikin.prototype = {
 
         this.sendGetRequest(this.set_control_info + '?' + query, response => {
           callback();
-        }, true /* skipCache */, true /* skipQueue */);
-    }, true /* skipCache */);
+        }, {skipCache: true, skipQueue: true});
+    }, {skipCache: true});
   },
 
   getSwingMode(callback) {
@@ -377,8 +377,8 @@ Daikin.prototype = {
       this.log.debug('setSwingMode: swing mode: %s, query is: %s', swing, query);
       this.sendGetRequest(this.set_control_info + '?' + query, response => {
         callback();
-      }, true /* skipCache */, true /* skipQueue */);
-    }, true /* skipCache */);
+      }, {skipCache: true, skipQueue: true});
+    }, {skipCache: true});
   },
 
   getHeaterCoolerState(callback) {
@@ -463,8 +463,8 @@ Daikin.prototype = {
                   this.log.info('setTargetHeaterCoolerState: query: %s', query);
                   this.sendGetRequest(this.set_control_info + '?' + query, response => {
                       callback();
-                  }, true /* skipCache */, true /* skipQueue */);
-              }, true /* skipCache */);
+                  }, {skipCache: true, skipQueue: true});
+              }, {skipCache: true});
         },
 
   getCurrentTemperature(callback) {
@@ -492,8 +492,8 @@ Daikin.prototype = {
             .replace(/dt3=[0-9.]+/, `dt3=${temp}`);
           this.sendGetRequest(this.set_control_info + '?' + query, response => {
                     callback();
-                }, true /* skipCache */, true /* skipQueue */);
-            }, true /* skipCache */);
+                }, {skipCache: true, skipQueue: true});
+            }, {skipCache: true});
         },
 
   getHeatingTemperature(callback) {
@@ -513,8 +513,8 @@ Daikin.prototype = {
               .replace(/dt3=[0-9.]+/, `dt3=${temp}`);
           this.sendGetRequest(this.set_control_info + '?' + query, response => {
                       callback();
-                  }, true /* skipCache */, true /* skipQueue */);
-              }, true /* skipCache */);
+                  }, {skipCache: true, skipQueue: true});
+              }, {skipCache: true});
           },
 
   identify: function (callback) {
@@ -645,8 +645,8 @@ getFanSpeed: function (callback) {
       this.log.warn('setFanStatus: going to send this query: %s', query);
       this.sendGetRequest(this.set_control_info + '?' + query, response => {
         callback();
-      }, true /* skipCache */, true /* skipQueue */);
-    }, true /* skipCache */);
+      }, {skipCache: true, skipQueue: true});
+    }, {skipCache: true});
   },
 
   setFanSpeed: function (value, callback) {
@@ -659,8 +659,8 @@ getFanSpeed: function (callback) {
       this.log.debug('setFanSpeed: Query is: %s', query);
       this.sendGetRequest(this.set_control_info + '?' + query, response => {
         callback();
-      }, true /* skipCache */, true /* skipQueue */);
-    }, true /* skipCache */);
+      }, {skipCache: true, skipQueue: true});
+    }, {skipCache: true});
   },
 
   getTemperatureDisplayUnits: function (callback) {

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function Daikin(log, config) {
 
   if (config.response === undefined) {
     this.log.warn('WARNING: your configuration is missing the parameter "response", using default');
-    this.response = 2000;
+    this.response = 5000;
     this.log.debug('Config: response is %s', this.response);
   } else {
     this.log.debug('Config: response is %s', config.response);
@@ -73,7 +73,7 @@ function Daikin(log, config) {
 
   if (config.deadline === undefined) {
       this.log.warn('WARNING: your configuration is missing the parameter "deadline", using default');
-      this.deadline = 60000;
+      this.deadline = 10000;
       this.log.debug('Config: deadline is %s', this.deadline);
     } else {
       this.log.debug('Config: deadline is %s', config.deadline);
@@ -82,7 +82,7 @@ function Daikin(log, config) {
 
   if (config.retries === undefined) {
       this.log.warn('WARNING: your configuration is missing the parameter "retries", using default of 5 retries');
-      this.retries = 5;
+      this.retries = 3;
       this.log.debug('Config: retries is %s', this.retries);
     } else {
       this.log.debug('Config: retries is %s', config.retries);
@@ -202,7 +202,7 @@ Daikin.prototype = {
   sendGetRequest(path, callback, options) {
     this.log.debug('attempting request: path: %s', path);
 
-    this._queueGetRequest(path, callback, options);
+    this._queueGetRequest(path, callback, options || {});
   },
 
   _queueGetRequest(path, callback, options) {
@@ -236,12 +236,12 @@ Daikin.prototype = {
     this.log.debug('requesting from API: path: %s', path);
     superagent
       .get(path)
-      // .retry(this.retries) // 5 // retry 5 times
+      .retry(this.retries) // retry 3 (default) times
       .timeout({
-        response: 2000, // 2000, // Wait 2 seconds for the server to start sending,
-        deadline: 5000 // 60000 // but allow 1 minute for the request to finish loading.
+        response: this.response, // Wait 5 (default) seconds for the server to start sending,
+        deadline: this.deadline // but allow 10 (default) seconds for the request to finish loading.
       })
-      // .use(this.throttle.plugin())
+      .use(this.throttle.plugin())
       .set('User-Agent', 'superagent')
       .set('Host', this.apiIP)
       .end((err, res) => {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "contributors": [
     "Pierre-Julien Cazaux",
     "greensouth",
-    "Fred de Gier"
+    "Fred de Gier",
+    "Fabian Leutgeb"
   ],
   "repository": {
     "type": "git",

--- a/queue.js
+++ b/queue.js
@@ -3,16 +3,29 @@ function Queue() {
   this.running = false;
 }
 
-Queue.prototype.add = function (callback) {
-  this.queue.push(() => {
+Queue.prototype.add = function (callback, prepend) {
+  const action = () => {
     const next = this.next.bind(this);
     callback(next);
-  });
+  };
+
+  if (prepend)
+    this.queue.unshift(action);
+  else
+    this.queue.push(action);
 
   if (!this.running)
     this.next();
 
   return this;
+};
+
+Queue.prototype.append = function (callback) {
+  return this.add(callback, false);
+};
+
+Queue.prototype.prepend = function (callback) {
+  return this.add(callback, true);
 };
 
 Queue.prototype.next = function () {


### PR DESCRIPTION
Fixes https://github.com/cbrandlehner/homebridge-daikin-local/issues/84 where units would turn off immediately after they have been turned on. Also https://github.com/cbrandlehner/homebridge-daikin-local/issues/90 and https://github.com/cbrandlehner/homebridge-daikin-local/pull/91 could be addressed via re-enabled requests throttling in this PR.

**Description**

Requests to persist settings on a device may have been queued after other requests, resulting in unexpected behavior in various situations.

Forcing specific requests to prepend to the queue resolves the issue.

**Changes**
- Add option to skip the queue (i.e., prepend)
- Improve request options handling
- Enable request throttling
- Use `response` and `deadline` options, and adjust defaults