### PR TITLE
Fix Faikin/Faikout fan speed control

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const {
   parseTemperatureDisplayUnits,
   daikinSpeedToRaw,
   rawToDaikinSpeed,
+  daikinToFaikinFanRate,
   isDaikinAutoMode,
   mapDaikinModeToCurrentHeaterCoolerState,
   mapDaikinModeToTargetHeaterCoolerState,
@@ -257,7 +258,6 @@ function Daikin(log, config) {
       this.get_model_info = this.apiroute + '/aircon/get_model_info';
       this.set_control_info = this.apiroute + '/aircon/set_control_info';
       this.basic_info = this.apiroute + '/common/basic_info';
-      this.faikin_control = this.apiroute + '/control'; // Faikout JSON control endpoint
       break;}
 
     default: {
@@ -626,123 +626,10 @@ Daikin.prototype = {
   },
 
   sendFaikinControl(controlData, callback) {
+    // Faikout firmware has no HTTP JSON control endpoint (POST /control returns
+    // 405); its own web UI sends native JSON commands over the /status WebSocket.
     this.log.debug('sendFaikinControl: Sending control command to Faikout: %s', JSON.stringify(controlData));
-
-    const path = this.apiroute + '/control';
-
-    this._resolveHost(resolvedIP => {
-      const resolvedPath = replaceHostInUrl(path, resolvedIP);
-
-      let urlProtocol = 'https:';
-      try {
-        urlProtocol = new URL(resolvedPath).protocol;
-      } catch {
-        urlProtocol = 'https:';
-      }
-
-      let request = superagent
-        .post(resolvedPath)
-        .send(controlData)
-        .set('Content-Type', 'application/json')
-        .set('User-Agent', 'superagent')
-        .set('Host', resolvedIP)
-        .retry(this.retries)
-        .timeout({
-          response: this.response,
-          deadline: this.deadline,
-        });
-
-      if (this.uuid !== '') {
-        request = request.set('X-Daikin-uuid', this.uuid);
-      }
-
-      if (urlProtocol === 'https:') {
-        request = applyHttpsTls(request);
-      } else {
-        request = request.agent(getDefaultHttpAgent());
-      }
-
-      request.end((error, response) => {
-        if (error) {
-          this.log.warn('sendFaikinControl: JSON control endpoint failed (%s), trying WebSocket fallback', error.message);
-          // Fallback to WebSocket for Faikout S21 protocol (econo/powerful/quiet modes)
-          this.sendFaikinWebSocketCommand(controlData, callback);
-          return;
-        }
-
-        const body = response && (response.text ?? (typeof response.body === 'string' ? response.body : JSON.stringify(response.body)));
-        this.log.debug('sendFaikinControl: response from API: %s', body);
-        return callback && callback(null, body);
-      });
-    });
-  },
-
-  sendFaikinControlFallback(controlData, callback) {
-    this.log.info('sendFaikinControlFallback: Converting JSON to traditional Daikin API: %s', JSON.stringify(controlData));
-
-    // Get current status first, then modify it with our changes
-    this.sendGetRequest(this.get_control_info, body => {
-      let query = body.replace(/,/g, '&');
-
-      // Convert JSON control data to query string parameters
-      if (controlData.power !== undefined) {
-        query = query.replace(/pow=[01]/, `pow=${controlData.power ? '1' : '0'}`);
-      }
-
-      if (controlData.mode !== undefined) {
-        const modeMap = {
-          H: '4', C: '3', A: '1', D: '2', F: '6',
-        };
-        const mode = modeMap[controlData.mode] || controlData.mode;
-        query = query.replace(/mode=[01234567]/, `mode=${mode}`);
-      }
-
-      if (controlData.temp !== undefined) {
-        const temp = Number.parseFloat(controlData.temp).toFixed(1);
-        query = query.replace(/stemp=[\d.]+/, `stemp=${temp}`);
-        query = query.replace(/dt3=[\d.]+/, `dt3=${temp}`);
-      }
-
-      if (controlData.fan !== undefined) {
-        query = query.replace(/f_rate=[01234567ABQ]/, `f_rate=${controlData.fan}`);
-        query = query.replace(/b_f_rate=[01234567ABQ]/, `b_f_rate=${controlData.fan}`);
-      }
-
-      if (controlData.swingh !== undefined || controlData.swingv !== undefined) {
-        // For traditional API, use f_dir: 0=no swing, 1=vertical, 2=horizontal, 3=both
-        const swingH = controlData.swingh;
-        const swingV = controlData.swingv;
-        let swingMode = '0';
-        if (swingH && swingV) swingMode = '3';
-        else if (swingV) swingMode = '1';
-        else if (swingH) swingMode = '2';
-        query = query.replace(/f_dir=[0123]/, `f_dir=${swingMode}`);
-        query = query.replace(/b_f_dir=[0123]/, `b_f_dir=${swingMode}`);
-      }
-
-      if (controlData.econo !== undefined) {
-        // Add en_economode parameter if not present in response
-        if (query.includes('en_economode=')) {
-          query = query.replace(/en_economode=[01]/, `en_economode=${controlData.econo ? '1' : '0'}`);
-        } else {
-          query += `&en_economode=${controlData.econo ? '1' : '0'}`;
-        }
-      }
-
-      if (controlData.powerful !== undefined) {
-        // Add en_powerful parameter if not present in response
-        if (query.includes('en_powerful=')) {
-          query = query.replace(/en_powerful=[01]/, `en_powerful=${controlData.powerful ? '1' : '0'}`);
-        } else {
-          query += `&en_powerful=${controlData.powerful ? '1' : '0'}`;
-        }
-      }
-
-      this.log.info('sendFaikinControlFallback: Using traditional API query: %s', query);
-      this.sendGetRequest(this.set_control_info + '?' + query, response => {
-        callback && callback(null, response);
-      }, {skipCache: true, skipQueue: true});
-    }, {skipCache: true});
+    this.sendFaikinWebSocketCommand(controlData, callback);
   },
 
   // WebSocket connection management for Faikout
@@ -1895,8 +1782,9 @@ getFanSpeed: function (callback) {
     this.log.debug('setFanSpeed: this translates to Daikin f_rate value: %s', value);
 
     if (this.isFaikin) {
-      // Faikout: use JSON control API to set fan speed only, without affecting swing
-      const controlData = {fan: String(value)};
+      // Faikout: set fan speed only, without affecting swing.
+      // Native control JSON expects A/Q/1-5 rather than Daikin A/B/3-7.
+      const controlData = {fan: daikinToFaikinFanRate(value)};
       this.log.info('setFanSpeed (Faikout): Sending fan control: %s', JSON.stringify(controlData));
       this.Fan_Speed = this.daikinSpeedToRaw(value);
       this.log.debug('setFanSpeed: update Speed: %s.', this.Fan_Speed);

--- a/src/utils.js
+++ b/src/utils.js
@@ -63,6 +63,20 @@ function daikinSpeedToRaw(daikinSpeed) {
   return raw;
 }
 
+/**
+ * Faikin/Faikout native control JSON expects fan values A (auto), Q (night) or
+ * '1'-'5' (manual levels), while the Daikin API uses A, B and '3'-'7'.
+ *
+ * @param {string} f_rate Daikin f_rate code.
+ * @returns {string} Faikin fan value.
+ */
+function daikinToFaikinFanRate(f_rate) {
+  const map = {
+    A: 'A', B: 'Q', 3: '1', 4: '2', 5: '3', 6: '4', 7: '5',
+  };
+  return map[f_rate] || 'A';
+}
+
 function parseTemperatureDisplayUnits(value, units) {
   if (value === units.FAHRENHEIT || value === 1 || value === '1' || value === 'F' || value === 'f') {
     return units.FAHRENHEIT;
@@ -313,7 +327,7 @@ function rawToDaikinSpeed(rawFanSpeed) {
     {min: 30, max: 40, value: '4'},
     {min: 40, max: 60, value: '5'},
     {min: 60, max: 80, value: '6'},
-    {min: 80, max: 100, value: '7'},
+    {min: 80, max: 101, value: '7'},
   ];
 
   for (const range of speedRanges) {
@@ -331,6 +345,7 @@ module.exports = {
   parseTemperatureDisplayUnits,
   daikinSpeedToRaw,
   rawToDaikinSpeed,
+  daikinToFaikinFanRate,
   isDaikinAutoMode,
   mapDaikinModeToCurrentHeaterCoolerState,
   mapDaikinModeToTargetHeaterCoolerState,

--- a/test/daikin.test.js
+++ b/test/daikin.test.js
@@ -105,13 +105,32 @@ test('setCoolingTemperature routes to heating setpoint when mode is 4', async ()
   assert.doesNotMatch(setRequest, /dt7=16\.0/);
 });
 
-test('Faikout system enables Faikout mode and control endpoint', () => {
+test('Faikout system enables Faikout mode', () => {
   const daikin = createDaikin({
     apiroute: 'http://192.168.1.88',
     system: 'Faikout',
   });
 
   assert.equal(daikin.isFaikin, true);
-  assert.equal(daikin.faikin_control, 'http://192.168.1.88/control');
   assert.equal(daikin.get_control_info, 'http://192.168.1.88/aircon/get_control_info');
+});
+
+test('Faikout setFanSpeed sends native fan values over the control channel', () => {
+  const daikin = createDaikin({
+    apiroute: 'http://192.168.1.88',
+    system: 'Faikout',
+  });
+
+  const sent = [];
+  daikin.sendFaikinWebSocketCommand = (controlData, callback) => {
+    sent.push(controlData);
+    if (callback) callback(null);
+  };
+
+  daikin.setFanSpeed(100, () => {});
+  daikin.setFanSpeed(25, () => {});
+  daikin.setFanSpeed(15, () => {});
+  daikin.setFanSpeed(5, () => {});
+
+  assert.deepEqual(sent, [{fan: '5'}, {fan: '1'}, {fan: 'A'}, {fan: 'Q'}]);
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -6,6 +6,7 @@ const {
   parseTemperatureDisplayUnits,
   daikinSpeedToRaw,
   rawToDaikinSpeed,
+  daikinToFaikinFanRate,
 } = require('../src/utils.js');
 
 const TemperatureDisplayUnits = {
@@ -35,4 +36,16 @@ test('rawToDaikinSpeed maps HomeKit percentages back to Daikin rates', () => {
   assert.equal(rawToDaikinSpeed(15), 'A');
   assert.equal(rawToDaikinSpeed(25), '3');
   assert.equal(rawToDaikinSpeed(90), '7');
+  assert.equal(rawToDaikinSpeed(100), '7');
+});
+
+test('daikinToFaikinFanRate maps Daikin rates to Faikin fan values', () => {
+  assert.equal(daikinToFaikinFanRate('A'), 'A');
+  assert.equal(daikinToFaikinFanRate('B'), 'Q');
+  assert.equal(daikinToFaikinFanRate('3'), '1');
+  assert.equal(daikinToFaikinFanRate('4'), '2');
+  assert.equal(daikinToFaikinFanRate('5'), '3');
+  assert.equal(daikinToFaikinFanRate('6'), '4');
+  assert.equal(daikinToFaikinFanRate('7'), '5');
+  assert.equal(daikinToFaikinFanRate('X'), 'A');
 });


### PR DESCRIPTION
## Problem

With `system: Faikout` (Faikin/Faikout ESP32 controller), the HomeKit fan speed slider misbehaves:

1. **Setting the slider to exactly 100% switches the unit to Auto**, and the slider then snaps back to 15%.
2. **Most other slider positions set the wrong speed** — e.g. 25% (Daikin `f_rate=3`, the lowest manual level) actually sets the Faikout's *middle* fan level, and 61–99% send values the firmware rejects entirely.
3. **Every control command logs a warning**: `sendFaikinControl: JSON control endpoint failed (Method Not Allowed), trying WebSocket fallback`.

## Root causes

1. `rawToDaikinSpeed()` uses half-open ranges (`min <= x < max`) and the top range is `{min: 80, max: 100}`, so exactly 100 matches nothing and falls through to the default `'A'` (auto). Auto then reads back as 15% via `daikinSpeedToRaw('A')`, which is the snap-back users see.

2. `setFanSpeed()` sent the raw Daikin `f_rate` code (`A`/`B`/`3`–`7`) as the native Faikin JSON `fan` value, but per the official docs the native control JSON expects `A` (Auto), `Q` (Night) or `'1'`–`'5'`. The official [Example HTTP API](https://codeberg.org/RevK/ESP32-Faikout/wiki/Example-HTTP-API) documents the mapping explicitly: "A=Auto, B=night, 3=1, 4=2, 5=3, 6=4, 7=5", and the [Advanced manual](https://codeberg.org/RevK/ESP32-Faikout/blob/main/Manuals/Advanced.md) confirms valid native `fan` values are A/Q/1–5.

3. The Faikout firmware has **no HTTP JSON control endpoint**: `POST /control` returns 405 Method Not Allowed and `GET /control` just serves the web UI. The firmware's own web UI sends single-field native JSON commands over the `/status` WebSocket (its source: `function w(n,v){var m=new Object();m[n]=v;ws.send(JSON.stringify(m));}`). The plugin already maintains that WebSocket connection, so the doomed POST + retries + warning + fallback on every single command was pure overhead.

## Changes

- `rawToDaikinSpeed()`: make the top speed range include 100 (`80–101`), so a full slider maps to `f_rate=7`.
- New `daikinToFaikinFanRate()` in utils implementing the documented Daikin→Faikin fan code mapping; `setFanSpeed()` uses it on the Faikin path (all other Faikin control paths already send valid native values: `'A'`/`'Q'`/booleans).
- `sendFaikinControl()` now sends over the `/status` WebSocket directly instead of first POSTing to the nonexistent `/control` endpoint and falling back. Removed the never-called `sendFaikinControlFallback()` and the unused `faikin_control` URL.

## Verification

- `npm test` passes (38 tests, including new cases for `rawToDaikinSpeed(100)`, the fan code mapping, and the native values `setFanSpeed` emits for Faikout).
- Verified against a real Faikout device (ESP32-Faikin firmware, S21 protocol):
  - `POST /control` → 405 confirmed; `GET /control` returns the web UI HTML.
  - Sending `{"fan":"5"}` over `ws://<host>/status` is accepted, echoed in the status stream, and reflected by the Daikin-compat API as `f_rate=7`.
  - Installed the patched plugin on Homebridge: the slider now holds at 100% (fan level 5), all slider positions map to the correct fan level, and the Method Not Allowed warnings are gone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Faikin/Faikout control reliability by routing commands through the supported control channel.
  * Fan-speed settings now use native Faikin/Faikout values for accurate operation.
  * Corrected high-range Daikin fan-speed conversion, including the value `100`.

* **Tests**
  * Expanded coverage for Faikin/Faikout control commands and fan-speed mappings.
  * Added validation for supported and fallback fan-rate conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->